### PR TITLE
Update readme: add missing dependencies for mac os

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ sudo apt-get -y -f install
 
 # MacOS
 ```
-brew install texinfo
+brew install texinfo automake libusb-compat hidapi
 export PATH=/usr/local/opt/texinfo/bin:$PATH
 
 cd openocd-git


### PR DESCRIPTION
The following dependencies had to be installed for the `make mac` command to succeed on macOS Monterey 12.6.1. This OS version is quite old, but I don't expect these dependencies to be included in the newer versions out of the box.